### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=libresprite&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMnV2eCUyMGxpYnJlc3ByaXRlLW1jcCUyMiU3RA%3D%3D)
 [![PyPI version](https://img.shields.io/pypi/v/libresprite-mcp)](https://pypi.org/project/libresprite-mcp/)
 
+<a href="https://glama.ai/mcp/servers/@Snehil-Shah/libresprite-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Snehil-Shah/libresprite-mcp/badge" alt="LibreSprite MCP server" />
+</a>
+
 > Prompt your way into LibreSprite
 
 Model Context Protocol (MCP) server for prompt-assisted editing, designing, and scripting inside LibreSprite.


### PR DESCRIPTION
This PR adds a badge for the [LibreSprite MCP](https://glama.ai/mcp/servers/@Snehil-Shah/libresprite-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Snehil-Shah/libresprite-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Snehil-Shah/libresprite-mcp/badge" alt="LibreSprite MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.