### PR TITLE
feat: add tools for common operations

### DIFF
--- a/src/libresprite_mcp/mcp_server.py
+++ b/src/libresprite_mcp/mcp_server.py
@@ -5,17 +5,20 @@ MCP server implementation that exposes tools for interacting with the libresprit
 import os
 from mcp.server.fastmcp import FastMCP, Context
 from .libresprite_proxy import LibrespriteProxy
+from .script_templates import ScriptTemplates
 
 
 class MCPServer:
     """The LibreSprite MCP Server."""
 
     def __init__(self, libresprite_proxy: LibrespriteProxy, server_name: str = "libresprite"):
-        # Cache the libresprite proxy instance
         self._libresprite_proxy = libresprite_proxy
 
         # Initialize FastMCP
         self.mcp = FastMCP(server_name)
+
+        # Initialize script templates
+        self.script_templates = ScriptTemplates()
 
         # Setup MCP tools, prompts, and resources
         self._setup_tools()
@@ -30,7 +33,9 @@ class MCPServer:
             """
             Run a JavaScript script inside Libresprite.
 
-            IMPORTANT: Make sure you are well versed with the documentation and examples provided in the resources `docs:reference` and `docs:examples`.
+            IMPORTANT: Make sure you are well versed with the
+            documentation and examples provided in the resources
+            `docs:reference` and `docs:examples`.
 
             Args:
                 script: The script to execute
@@ -38,6 +43,262 @@ class MCPServer:
             Returns:
                 Console output
             """
+            return self._libresprite_proxy.run_script(script, ctx)
+        
+        @self.mcp.tool()
+        def create_sprite(width: int, height: int, color_mode: str, ctx: Context) -> str:
+            """
+            Creates a new sprite with specified dimensions and color mode.
+
+            Args:
+                width: Width of the sprite
+                height: Height of the sprite
+                color_mode: Color mode (default is "RGB")
+            
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.create_sprite(width, height, color_mode)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def create_layer(name: str, ctx: Context) -> str:
+            """
+            Adds a new layer to the active sprite.
+
+            Args:
+            name: Name for the new layer (default is "New Layer")
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.create_layer(name)
+            return self._libresprite_proxy.run_script(script, ctx)
+        
+        @self.mcp.tool()
+        def fill_layer(color_r: int, color_g: int, color_b: int, color_a: int, ctx: Context) -> str:
+            """
+            Fill the active layer with a solid color.
+
+            Args:
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)  
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255, default is 255)
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.fill_layer(color_r, color_g, color_b, color_a)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def draw_circle(center_x: int, center_y: int, radius: int,
+                        color_r: int, color_g: int, color_b: int,
+                        color_a: int, filled: bool,
+                        ctx: Context) -> str:
+            """
+            Draw a circle on the active layer.
+
+            Args:
+                center_x: X coordinate of circle center
+                center_y: Y coordinate of circle center
+                radius: Circle radius in pixels
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255, default is 255)
+                filled: Whether to fill the circle (default is True)
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.draw_circle(center_x,
+                                                    center_y, radius,
+                                                    color_r, color_g,
+                                                    color_b, color_a, 
+                                                    filled)
+            return self._libresprite_proxy.run_script(script, ctx)
+        
+        @self.mcp.tool()
+        def get_sprite_info(ctx: Context) -> str:
+            """
+            Get information about the active sprite including 
+            dimensions, layers, and frames.
+
+            Returns:
+                Sprite information and layer details
+            """
+            script = self.script_templates.get_sprite_info()
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def draw_rectangle(x: int, y: int, width: int, height: int,
+                            color_r: int, color_g: int, color_b: int,
+                            color_a: int, filled: bool,
+                            ctx: Context) -> str:
+            """
+            Draw a rectangle on the active layer.
+
+            Args:
+                x: Top-left x coordinate
+                y: Top-left y coordinate
+                width: Rectangle width
+                height: Rectangle height
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255)
+                filled: Whether to fill the rectangle
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.draw_rectangle(x, y, width, height,
+                                                        color_r, color_g, color_b, color_a, filled)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def draw_line(x1: int, y1: int, x2: int, y2: int,
+                        color_r: int, color_g: int, color_b: int,
+                        color_a: int, thickness: int,
+                        ctx: Context) -> str:
+            """
+            Draw a line on the active layer.
+
+            Args:
+                x1: Start x coordinate
+                y1: Start y coordinate
+                x2: End x coordinate
+                y2: End y coordinate
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255)
+                thickness: Line thickness in pixels
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.draw_line(x1, y1, x2, y2,
+                                                    color_r, color_g, color_b, color_a, thickness)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def draw_ellipse(center_x: int, center_y: int, width: int, height: int,
+                        color_r: int, color_g: int, color_b: int,
+                        color_a: int, filled: bool,
+                        ctx: Context) -> str:
+            """
+            Draw an ellipse on the active layer.
+
+            Args:
+                center_x: Center x coordinate
+                center_y: Center y coordinate
+                width: Ellipse width
+                height: Ellipse height
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255)
+                filled: Whether to fill the ellipse
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.draw_ellipse(center_x, center_y, width, height,
+                                                        color_r, color_g, color_b, color_a, filled)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def put_pixel(x: int, y: int, color_r: int, color_g: int, color_b: int, color_a: int, ctx: Context) -> str:
+            """
+            Set a single pixel color.
+
+            Args:
+                x: X coordinate
+                y: Y coordinate
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255)
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.put_pixel(x, y, color_r, color_g, color_b, color_a)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def flood_fill(x: int, y: int, color_r: int, color_g: int, color_b: int, color_a: int, ctx: Context) -> str:
+            """
+            Flood fill an area with color.
+
+            Args:
+                x: X coordinate to start fill
+                y: Y coordinate to start fill
+                color_r: Red component (0-255)
+                color_g: Green component (0-255)
+                color_b: Blue component (0-255)
+                color_a: Alpha component (0-255)
+
+            Returns:
+                Confirmation message with fill count
+            """
+            script = self.script_templates.flood_fill(x, y, color_r, color_g, color_b, color_a)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def set_active_layer(layer_number: int, ctx: Context) -> str:
+            """
+            Switch to a specific layer.
+
+            Args:
+                layer_number: Layer index (0-based from bottom)
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.set_active_layer(layer_number)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+        @self.mcp.tool()
+        def delete_layer(layer_number: int, ctx: Context) -> str:
+            """
+            Delete a layer.
+
+            Args:
+                layer_number: Layer index to delete (0-based from bottom)
+
+            Returns:
+                Confirmation message
+            """
+            script = self.script_templates.delete_layer(layer_number)
+            return self._libresprite_proxy.run_script(script, ctx)
+
+
+
+        @self.mcp.tool()
+        def replace_color(old_color_r: int, old_color_g: int, old_color_b: int,
+                            new_color_r: int, new_color_g: int, new_color_b: int,
+                            new_color_a: int, ctx: Context) -> str:
+            """
+            Replace one color with another throughout the image.
+
+            Args:
+                old_color_r: Old color red component (0-255)
+                old_color_g: Old color green component (0-255)
+                old_color_b: Old color blue component (0-255)
+                new_color_r: New color red component (0-255)
+                new_color_g: New color green component (0-255)
+                new_color_b: New color blue component (0-255)
+                new_color_a: New color alpha component (0-255)
+
+            Returns:
+                Confirmation message with replacement count
+            """
+            script = self.script_templates.replace_color(old_color_r, old_color_g, old_color_b,
+                                                        new_color_r, new_color_g, new_color_b, new_color_a)
             return self._libresprite_proxy.run_script(script, ctx)
 
     def _setup_resources(self):
@@ -82,10 +343,32 @@ class MCPServer:
             return f"""
             Libresprite is a program for creating and editing pixel art and animations using JavaScript.
 
-            Before proceeding, please ensure you are well versed with the documentation and examples provided in the resources `docs:reference` and `docs:examples`.
+            IMPORTANT: You have dedicated MCP tools available. ALWAYS use these tools instead of run_script():
+
+            SPRITE & LAYER MANAGEMENT:
+            - create_sprite(width, height, color_mode) - CREATE NEW SPRITES  
+            - create_layer(name) - ADD LAYERS
+            - set_active_layer(layer_number) - SWITCH TO SPECIFIC LAYER
+            - delete_layer(layer_number) - DELETE LAYERS
+            - get_sprite_info() - GET SPRITE DETAILS
+
+            DRAWING TOOLS:
+            - fill_layer(r, g, b, a) - SOLID COLOR FILLS
+            - draw_circle(cx, cy, radius, r, g, b, a, filled) - DRAW CIRCLES
+            - draw_rectangle(x, y, width, height, r, g, b, a, filled) - DRAW RECTANGLES
+            - draw_line(x1, y1, x2, y2, r, g, b, a, thickness) - DRAW LINES
+            - draw_ellipse(cx, cy, width, height, r, g, b, a, filled) - DRAW ELLIPSES
+
+            PIXEL OPERATIONS:
+            - put_pixel(x, y, r, g, b, a) - SET SINGLE PIXEL
+            - flood_fill(x, y, r, g, b, a) - FLOOD FILL AREAS
+            - replace_color(old_r, old_g, old_b, new_r, new_g, new_b, new_a) - REPLACE COLORS
 
             You can use the `run_script` tool to execute JavaScript scripts in the context of libresprite.
+            ONLY use `run_script` for complex custom operations not covered by the above tools.
 
+            Before proceeding, please ensure you are well versed with the documentation and examples provided in the resources `docs:reference` and `docs:examples`.
+            
             Here's what you need to do using the above tools and resources:
 
             {prompt}

--- a/src/libresprite_mcp/mcp_server.py
+++ b/src/libresprite_mcp/mcp_server.py
@@ -249,20 +249,6 @@ class MCPServer:
             return self._libresprite_proxy.run_script(script, ctx)
 
         @self.mcp.tool()
-        def set_active_layer(layer_number: int, ctx: Context) -> str:
-            """
-            Switch to a specific layer.
-
-            Args:
-                layer_number: Layer index (0-based from bottom)
-
-            Returns:
-                Confirmation message
-            """
-            script = self.script_templates.set_active_layer(layer_number)
-            return self._libresprite_proxy.run_script(script, ctx)
-
-        @self.mcp.tool()
         def delete_layer(layer_number: int, ctx: Context) -> str:
             """
             Delete a layer.
@@ -275,8 +261,6 @@ class MCPServer:
             """
             script = self.script_templates.delete_layer(layer_number)
             return self._libresprite_proxy.run_script(script, ctx)
-
-
 
         @self.mcp.tool()
         def replace_color(old_color_r: int, old_color_g: int, old_color_b: int,
@@ -348,7 +332,6 @@ class MCPServer:
             SPRITE & LAYER MANAGEMENT:
             - create_sprite(width, height, color_mode) - CREATE NEW SPRITES  
             - create_layer(name) - ADD LAYERS
-            - set_active_layer(layer_number) - SWITCH TO SPECIFIC LAYER
             - delete_layer(layer_number) - DELETE LAYERS
             - get_sprite_info() - GET SPRITE DETAILS
 

--- a/src/libresprite_mcp/resources/examples.txt
+++ b/src/libresprite_mcp/resources/examples.txt
@@ -14,11 +14,6 @@ Use the `create_layer` tool to add layers:
 - `create_layer(name="Background Layer")`
 - Adds a new layer with the specified name
 
-### Switching Between Layers
-Use the `set_active_layer` tool to switch layers:
-- `set_active_layer(layer_number=1)`
-- Switches to layer 1 (0-based from bottom)
-
 ### Filling a Layer with Color
 Use the `fill_layer` tool to fill the active layer:
 - `fill_layer(color_r=255, color_g=0, color_b=0, color_a=255)`
@@ -304,17 +299,30 @@ create_layer(name="Details")
 
 **Step 2: Work on background layer**
 ```
-# Switch to background layer and fill with light blue
-set_active_layer(layer_number=0)
-fill_layer(color_r=173, color_g=216, color_b=230, color_a=255)
+# Work with background layer (layer 0) using JavaScript
+# Note: MCP tools work on the currently active layer, so we use JavaScript for layer-specific operations
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(0);
+const image = layer.cel(0).image;
+const col = app.pixelColor;
+image.clear(col.rgba(173, 216, 230, 255));
+console.log("Background layer filled with light blue");
+''')
 ```
 
 **Step 3: Add shapes on shapes layer**
 ```
-# Switch to shapes layer
-set_active_layer(layer_number=1)
+# Work with shapes layer (layer 1) - use MCP tools if it's the active layer
+# Or use JavaScript to work on specific layer
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(1);
+const image = layer.cel(0).image;
+console.log("Ready to draw on shapes layer");
+''')
 
-# Draw various shapes
+# Draw various shapes (these will work on the currently active layer)
 draw_rectangle(x=20, y=20, width=40, height=30, color_r=255, color_g=0, color_b=0, color_a=255, filled=true)
 draw_circle(center_x=90, center_y=35, radius=15, color_r=0, color_g=255, color_b=0, color_a=255, filled=false)
 draw_ellipse(center_x=64, center_y=90, width=60, height=30, color_r=255, color_g=255, color_b=0, color_a=255, filled=true)
@@ -323,12 +331,18 @@ draw_line(x1=10, y1=110, x2=118, y2=10, color_r=255, color_g=0, color_b=255, col
 
 **Step 4: Add details**
 ```
-# Switch to details layer
-set_active_layer(layer_number=2)
+# Work with details layer (layer 2) using pixel manipulation
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(2);
+const image = layer.cel(0).image;
+const col = app.pixelColor;
 
-# Add some accent pixels
-put_pixel(x=40, y=35, color_r=255, color_g=255, color_b=255, color_a=255)
-put_pixel(x=90, y=35, color_r=0, color_g=0, color_b=0, color_a=255)
+// Add accent pixels directly to this layer
+image.putPixel(40, 35, col.rgba(255, 255, 255, 255));
+image.putPixel(90, 35, col.rgba(0, 0, 0, 255));
+console.log("Details added to layer 2");
+''')
 
 # Check what we created
 get_sprite_info()
@@ -346,33 +360,66 @@ create_layer(name="Details")
 
 **Step 2: Draw character head**
 ```
-# Switch to head layer
-set_active_layer(layer_number=0)
+# Work with head layer (layer 0) using JavaScript
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(0);
+const image = layer.cel(0).image;
+const col = app.pixelColor;
 
-# Draw head (filled circle)
-draw_circle(center_x=16, center_y=12, radius=8, color_r=255, color_g=220, color_b=177, color_a=255, filled=true)
+// Draw head (filled circle) - simple circle drawing
+const centerX = 16, centerY = 12, radius = 8;
+const headColor = col.rgba(255, 220, 177, 255);
+for (let y = -radius; y <= radius; y++) {
+    for (let x = -radius; x <= radius; x++) {
+        if (x*x + y*y <= radius*radius) {
+            image.putPixel(centerX + x, centerY + y, headColor);
+        }
+    }
+}
+console.log("Head drawn on layer 0");
+''')
 ```
 
 **Step 3: Draw body**
 ```
-# Switch to body layer
-set_active_layer(layer_number=1)
+# Work with body layer (layer 1) using JavaScript  
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(1);
+const image = layer.cel(0).image;
+const col = app.pixelColor;
 
-# Draw body (rectangle)
-draw_rectangle(x=12, y=18, width=8, height=12, color_r=0, color_g=100, color_b=200, color_a=255, filled=true)
+// Draw body (rectangle)
+const bodyColor = col.rgba(0, 100, 200, 255);
+for (let y = 18; y < 30; y++) {
+    for (let x = 12; x < 20; x++) {
+        image.putPixel(x, y, bodyColor);
+    }
+}
+console.log("Body drawn on layer 1");
+''')
 ```
 
 **Step 4: Add facial features**
 ```
-# Switch to details layer
-set_active_layer(layer_number=2)
+# Work with details layer (layer 2) using JavaScript
+run_script(script='''
+const sprite = app.activeSprite;
+const layer = sprite.layer(2);
+const image = layer.cel(0).image;
+const col = app.pixelColor;
 
-# Eyes
-put_pixel(x=13, y=10, color_r=0, color_g=0, color_b=0, color_a=255)
-put_pixel(x=19, y=10, color_r=0, color_g=0, color_b=0, color_a=255)
+// Eyes
+image.putPixel(13, 10, col.rgba(0, 0, 0, 255));
+image.putPixel(19, 10, col.rgba(0, 0, 0, 255));
 
-# Mouth (small line)
-draw_line(x1=15, y1=14, x2=17, y2=14, color_r=255, color_g=0, color_b=0, color_a=255, thickness=1)
+// Mouth (small line)
+image.putPixel(15, 14, col.rgba(255, 0, 0, 255));
+image.putPixel(16, 14, col.rgba(255, 0, 0, 255));
+image.putPixel(17, 14, col.rgba(255, 0, 0, 255));
+console.log("Facial features added to layer 2");
+''')
 ```
 
 ### Pattern Creation with Flood Fill

--- a/src/libresprite_mcp/resources/examples.txt
+++ b/src/libresprite_mcp/resources/examples.txt
@@ -1,6 +1,78 @@
 # Examples
 
-## Random
+## MCP Tool Examples
+
+These examples show how to use the abstracted MCP tools for common operations. These tools handle the JavaScript complexity for you.
+
+### Creating a New Sprite
+Use the `create_sprite` tool to quickly create a new sprite:
+- `create_sprite(width=64, height=64, color_mode="RGB")`
+- Creates a 64x64 RGB sprite
+
+### Adding a New Layer
+Use the `create_layer` tool to add layers:
+- `create_layer(name="Background Layer")`
+- Adds a new layer with the specified name
+
+### Switching Between Layers
+Use the `set_active_layer` tool to switch layers:
+- `set_active_layer(layer_number=1)`
+- Switches to layer 1 (0-based from bottom)
+
+### Filling a Layer with Color
+Use the `fill_layer` tool to fill the active layer:
+- `fill_layer(color_r=255, color_g=0, color_b=0, color_a=255)`
+- Fills the active layer with solid red
+
+### Drawing Shapes
+Use the drawing tools to create basic shapes:
+
+#### Circles
+- `draw_circle(center_x=32, center_y=32, radius=10, color_r=0, color_g=255, color_b=0, color_a=255, filled=true)`
+- Draws a filled green circle at center (32,32) with radius 10
+
+#### Rectangles
+- `draw_rectangle(x=10, y=10, width=40, height=20, color_r=255, color_g=0, color_b=0, color_a=255, filled=false)`
+- Draws a red rectangle outline
+
+#### Lines
+- `draw_line(x1=0, y1=0, x2=63, y2=63, color_r=0, color_g=0, color_b=255, color_a=255, thickness=2)`
+- Draws a diagonal blue line with thickness 2
+
+#### Ellipses
+- `draw_ellipse(center_x=32, center_y=32, width=50, height=30, color_r=255, color_g=255, color_b=0, color_a=255, filled=true)`
+- Draws a filled yellow ellipse
+
+### Pixel Operations
+Use pixel tools for precise control:
+
+#### Setting Individual Pixels
+- `put_pixel(x=50, y=50, color_r=255, color_g=0, color_b=0, color_a=255)`
+- Sets a single red pixel at (50,50)
+
+#### Flood Filling Areas
+- `flood_fill(x=32, y=32, color_r=0, color_g=255, color_b=0, color_a=255)`
+- Flood fills the area starting from (32,32) with green
+
+### Layer Management
+Use layer management tools for organizing your artwork:
+
+#### Managing Layers
+- `delete_layer(layer_number=1)`
+- Deletes layer 1
+
+### Color Replacement
+Use color tools to change existing artwork:
+
+#### Color Replacement
+- `replace_color(old_color_r=255, old_color_g=255, old_color_b=255, new_color_r=0, new_color_g=0, new_color_b=255, new_color_a=255)`
+- Replaces all white pixels with blue
+
+## JavaScript Examples
+
+These examples show direct JavaScript scripting for more complex operations.
+
+### Random
 
 ```javascript
 const col = app.pixelColor;
@@ -211,4 +283,212 @@ function onEvent(eventName) {
     if (typeof handler == 'function')
         handler();
 }
+```
+
+## Combined Workflow Examples
+
+These examples show how to combine MCP tools with JavaScript for complete workflows.
+
+### Creating a Sprite with Multiple Layers and Basic Shapes
+
+**Step 1: Use MCP tools for setup**
+```
+# Create the canvas
+create_sprite(width=128, height=128, color_mode="RGB")
+
+# Create layers
+create_layer(name="Background")
+create_layer(name="Shapes")
+create_layer(name="Details")
+```
+
+**Step 2: Work on background layer**
+```
+# Switch to background layer and fill with light blue
+set_active_layer(layer_number=0)
+fill_layer(color_r=173, color_g=216, color_b=230, color_a=255)
+```
+
+**Step 3: Add shapes on shapes layer**
+```
+# Switch to shapes layer
+set_active_layer(layer_number=1)
+
+# Draw various shapes
+draw_rectangle(x=20, y=20, width=40, height=30, color_r=255, color_g=0, color_b=0, color_a=255, filled=true)
+draw_circle(center_x=90, center_y=35, radius=15, color_r=0, color_g=255, color_b=0, color_a=255, filled=false)
+draw_ellipse(center_x=64, center_y=90, width=60, height=30, color_r=255, color_g=255, color_b=0, color_a=255, filled=true)
+draw_line(x1=10, y1=110, x2=118, y2=10, color_r=255, color_g=0, color_b=255, color_a=255, thickness=3)
+```
+
+**Step 4: Add details**
+```
+# Switch to details layer
+set_active_layer(layer_number=2)
+
+# Add some accent pixels
+put_pixel(x=40, y=35, color_r=255, color_g=255, color_b=255, color_a=255)
+put_pixel(x=90, y=35, color_r=0, color_g=0, color_b=0, color_a=255)
+
+# Check what we created
+get_sprite_info()
+```
+
+### Creating Pixel Art Character
+
+**Step 1: Setup with MCP tools**
+```
+create_sprite(width=32, height=32, color_mode="RGB")
+create_layer(name="Head")
+create_layer(name="Body")
+create_layer(name="Details")
+```
+
+**Step 2: Draw character head**
+```
+# Switch to head layer
+set_active_layer(layer_number=0)
+
+# Draw head (filled circle)
+draw_circle(center_x=16, center_y=12, radius=8, color_r=255, color_g=220, color_b=177, color_a=255, filled=true)
+```
+
+**Step 3: Draw body**
+```
+# Switch to body layer
+set_active_layer(layer_number=1)
+
+# Draw body (rectangle)
+draw_rectangle(x=12, y=18, width=8, height=12, color_r=0, color_g=100, color_b=200, color_a=255, filled=true)
+```
+
+**Step 4: Add facial features**
+```
+# Switch to details layer
+set_active_layer(layer_number=2)
+
+# Eyes
+put_pixel(x=13, y=10, color_r=0, color_g=0, color_b=0, color_a=255)
+put_pixel(x=19, y=10, color_r=0, color_g=0, color_b=0, color_a=255)
+
+# Mouth (small line)
+draw_line(x1=15, y1=14, x2=17, y2=14, color_r=255, color_g=0, color_b=0, color_a=255, thickness=1)
+```
+
+### Pattern Creation with Flood Fill
+
+**Step 1: Create base pattern**
+```
+create_sprite(width=64, height=64, color_mode="RGB")
+
+# Create a checkerboard pattern using rectangles
+draw_rectangle(x=0, y=0, width=32, height=32, color_r=255, color_g=255, color_b=255, color_a=255, filled=true)
+draw_rectangle(x=32, y=32, width=32, height=32, color_r=255, color_g=255, color_b=255, color_a=255, filled=true)
+```
+
+**Step 2: Add pattern elements with flood fill**
+```
+# Add some circular areas to flood fill
+draw_circle(center_x=16, center_y=16, radius=8, color_r=100, color_g=100, color_b=100, color_a=255, filled=false)
+draw_circle(center_x=48, center_y=48, radius=8, color_r=100, color_g=100, color_b=100, color_a=255, filled=false)
+
+# Flood fill the circles with different colors
+flood_fill(x=16, y=16, color_r=255, color_g=0, color_b=0, color_a=255)
+flood_fill(x=48, y=48, color_r=0, color_g=0, color_b=255, color_a=255)
+```
+
+### Geometric Art Creation
+
+**Step 1: Setup canvas**
+```
+create_sprite(width=100, height=100, color_mode="RGB")
+fill_layer(color_r=0, color_g=0, color_b=0, color_a=255)  # Black background
+```
+
+**Step 2: Create geometric pattern**
+```
+# Draw overlapping shapes with transparency
+draw_circle(center_x=30, center_y=30, radius=25, color_r=255, color_g=0, color_b=0, color_a=128, filled=true)
+draw_circle(center_x=70, center_y=30, radius=25, color_r=0, color_g=255, color_b=0, color_a=128, filled=true)
+draw_circle(center_x=50, center_y=60, radius=25, color_r=0, color_g=0, color_b=255, color_a=128, filled=true)
+
+# Add connecting lines
+draw_line(x1=30, y1=30, x2=70, y2=30, color_r=255, color_g=255, color_b=255, color_a=255, thickness=2)
+draw_line(x1=70, y1=30, x2=50, y2=60, color_r=255, color_g=255, color_b=255, color_a=255, thickness=2)
+draw_line(x1=50, y1=60, x2=30, y2=30, color_r=255, color_g=255, color_b=255, color_a=255, thickness=2)
+```
+
+### Pixel Art Icon Creation
+
+**Step 1: Setup small canvas for icon**
+```
+create_sprite(width=16, height=16, color_mode="RGB")
+fill_layer(color_r=240, color_g=240, color_b=240, color_a=255)  # Light gray background
+```
+
+**Step 2: Create simple house icon**
+```
+# House base
+draw_rectangle(x=4, y=8, width=8, height=6, color_r=139, color_g=69, color_b=19, color_a=255, filled=true)
+
+# Roof
+draw_line(x1=2, y1=8, x2=8, y2=4, color_r=165, color_g=42, color_b=42, color_a=255, thickness=1)
+draw_line(x1=8, y1=4, x2=14, y2=8, color_r=165, color_g=42, color_b=42, color_a=255, thickness=1)
+flood_fill(x=8, y=6, color_r=165, color_g=42, color_b=42, color_a=255)
+
+# Door
+draw_rectangle(x=6, y=10, width=2, height=4, color_r=101, color_g=67, color_b=33, color_a=255, filled=true)
+
+# Window
+put_pixel(x=9, y=10, color_r=135, color_g=206, color_b=235, color_a=255)
+put_pixel(x=10, y=10, color_r=135, color_g=206, color_b=235, color_a=255)
+put_pixel(x=9, y=11, color_r=135, color_g=206, color_b=235, color_a=255)
+put_pixel(x=10, y=11, color_r=135, color_g=206, color_b=235, color_a=255)
+```
+
+### Animation Setup
+
+**Step 1: Create sprite with MCP tools**
+```
+create_sprite(width=64, height=64, color_mode="RGB")
+create_layer(name="Animation Layer")
+```
+
+**Step 2: Create animation frames with JavaScript**
+```javascript
+// Create bouncing ball animation
+const sprite = app.activeSprite;
+const frameCount = 8;
+const col = app.pixelColor;
+
+app.command.setParameter("content", "current");
+for (let frame = 0; frame < frameCount; frame++) {
+    if (frame > 0) {
+        app.command.NewFrame();
+    }
+    
+    const layer = sprite.layer(0);
+    const img = layer.cel(frame).image;
+    
+    // Clear frame
+    img.clear(col.rgba(255, 255, 255, 0));
+    
+    // Calculate ball position (bouncing)
+    const y = Math.abs(Math.sin(frame / frameCount * Math.PI)) * 40 + 10;
+    
+    // Draw ball
+    for (let dy = -5; dy <= 5; dy++) {
+        for (let dx = -5; dx <= 5; dx++) {
+            if (dx*dx + dy*dy <= 25) { // Circle shape
+                const px = 32 + dx;
+                const py = y + dy;
+                if (px >= 0 && px < img.width && py >= 0 && py < img.height) {
+                    img.putPixel(px, py, col.rgba(255, 0, 0, 255));
+                }
+            }
+        }
+    }
+}
+app.command.clearParameters();
+console.log("Animation frames created");
 ```

--- a/src/libresprite_mcp/resources/reference.txt
+++ b/src/libresprite_mcp/resources/reference.txt
@@ -1,3 +1,285 @@
+# MCP Tools Reference
+
+These are high-level tools available through the MCP server that abstract common LibreSprite operations. Use these for simple, repetitive tasks instead of writing JavaScript manually.
+
+## Tool: create_sprite
+Creates a new sprite with specified dimensions and color mode.
+
+**Parameters:**
+- `width` (int): Width of the sprite in pixels
+- `height` (int): Height of the sprite in pixels  
+- `color_mode` (str): Color mode - "RGB", "RGBA", "GRAYSCALE", or "BITMAP"
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+create_sprite(width=128, height=128, color_mode="RGB")
+```
+
+## Tool: create_layer
+Adds a new layer to the active sprite.
+
+**Parameters:**
+- `name` (str): Name for the new layer (default: "New Layer")
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+create_layer(name="Character Layer")
+```
+
+## Tool: set_active_layer
+Switch to a specific layer.
+
+**Parameters:**
+- `layer_number` (int): Layer index (0-based from bottom)
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+set_active_layer(layer_number=1)
+```
+
+## Tool: fill_layer
+Fill the active layer with a solid color.
+
+**Parameters:**
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255, default: 255)
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+fill_layer(color_r=255, color_g=128, color_b=0, color_a=255)
+```
+
+## Tool: draw_circle
+Draw a circle on the active layer.
+
+**Parameters:**
+- `center_x` (int): X coordinate of circle center
+- `center_y` (int): Y coordinate of circle center
+- `radius` (int): Circle radius in pixels
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255, default: 255)
+- `filled` (bool): Whether to fill the circle (default: true)
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+draw_circle(center_x=64, center_y=64, radius=20, color_r=0, color_g=0, color_b=255, color_a=255, filled=true)
+```
+
+## Tool: draw_rectangle
+Draw a rectangle on the active layer.
+
+**Parameters:**
+- `x` (int): Top-left x coordinate
+- `y` (int): Top-left y coordinate
+- `width` (int): Rectangle width
+- `height` (int): Rectangle height
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255)
+- `filled` (bool): Whether to fill the rectangle
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+draw_rectangle(x=10, y=10, width=50, height=30, color_r=255, color_g=0, color_b=0, color_a=255, filled=true)
+```
+
+## Tool: draw_line
+Draw a line on the active layer.
+
+**Parameters:**
+- `x1` (int): Start x coordinate
+- `y1` (int): Start y coordinate
+- `x2` (int): End x coordinate
+- `y2` (int): End y coordinate
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255)
+- `thickness` (int): Line thickness in pixels
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+draw_line(x1=0, y1=0, x2=100, y2=100, color_r=0, color_g=255, color_b=0, color_a=255, thickness=2)
+```
+
+## Tool: draw_ellipse
+Draw an ellipse on the active layer.
+
+**Parameters:**
+- `center_x` (int): Center x coordinate
+- `center_y` (int): Center y coordinate
+- `width` (int): Ellipse width
+- `height` (int): Ellipse height
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255)
+- `filled` (bool): Whether to fill the ellipse
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+draw_ellipse(center_x=64, center_y=64, width=80, height=40, color_r=255, color_g=255, color_b=0, color_a=255, filled=false)
+```
+
+## Tool: put_pixel
+Set a single pixel color.
+
+**Parameters:**
+- `x` (int): X coordinate
+- `y` (int): Y coordinate
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255)
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+put_pixel(x=50, y=50, color_r=255, color_g=0, color_b=0, color_a=255)
+```
+
+## Tool: flood_fill
+Flood fill an area with color.
+
+**Parameters:**
+- `x` (int): X coordinate to start fill
+- `y` (int): Y coordinate to start fill
+- `color_r` (int): Red component (0-255)
+- `color_g` (int): Green component (0-255)
+- `color_b` (int): Blue component (0-255)
+- `color_a` (int): Alpha component (0-255)
+
+**Returns:** Confirmation message with fill count
+
+**Example Usage:**
+```
+flood_fill(x=32, y=32, color_r=0, color_g=0, color_b=255, color_a=255)
+```
+
+## Tool: get_sprite_info
+Get information about the active sprite including dimensions, layers, and frames.
+
+**Parameters:** None
+
+**Returns:** Sprite information and layer details
+
+**Example Usage:**
+```
+get_sprite_info()
+```
+
+## Tool: delete_layer
+Delete a layer.
+
+**Parameters:**
+- `layer_number` (int): Layer index to delete (0-based from bottom)
+
+**Returns:** Confirmation message
+
+**Example Usage:**
+```
+delete_layer(layer_number=2)
+```
+
+## Tool: replace_color
+Replace one color with another throughout the image.
+
+**Parameters:**
+- `old_color_r` (int): Old color red component (0-255)
+- `old_color_g` (int): Old color green component (0-255)
+- `old_color_b` (int): Old color blue component (0-255)
+- `new_color_r` (int): New color red component (0-255)
+- `new_color_g` (int): New color green component (0-255)
+- `new_color_b` (int): New color blue component (0-255)
+- `new_color_a` (int): New color alpha component (0-255)
+
+**Returns:** Confirmation message with replacement count
+
+**Example Usage:**
+```
+replace_color(old_color_r=255, old_color_g=255, old_color_b=255, new_color_r=0, new_color_g=0, new_color_b=255, new_color_a=255)
+```
+
+## Tool: run_script
+Run custom JavaScript code inside LibreSprite for advanced operations.
+
+**Parameters:**
+- `script` (str): The JavaScript code to execute
+
+**Returns:** Console output from the script execution
+
+**Example Usage:**
+```javascript
+script = '''
+const col = app.pixelColor;
+const img = app.activeImage;
+for (let y = 0; y < img.height; y++) {
+    for (let x = 0; x < img.width; x++) {
+        const gray = Math.random() * 255;
+        img.putPixel(x, y, col.rgba(gray, gray, gray, 255));
+    }
+}
+console.log("Random noise applied");
+'''
+run_script(script=script)
+```
+
+## When to Use MCP Tools vs JavaScript
+
+**Use MCP Tools for:**
+- Creating new sprites and layers
+- Simple shape drawing (circles, rectangles, lines, ellipses)
+- Single pixel operations
+- Quick color fills and flood fills
+- Layer management (switching, deleting)
+- Color replacement throughout images
+- Getting sprite information
+- Repetitive, straightforward operations
+- When you need type safety and parameter validation
+
+**Use JavaScript (run_script) for:**
+- Complex pixel manipulation algorithms
+- Custom drawing functions with complex logic
+- Animation frame creation
+- Advanced image processing effects
+- UI dialogs and user interaction
+- Operations requiring loops or complex mathematical calculations
+- When you need access to the full LibreSprite API
+- Complex gradient effects or procedural generation
+- Text rendering with custom fonts
+- Advanced layer manipulation and reordering
+- Complex selection operations
+
+**Best Practice:** Start with MCP tools for setup and basic operations, then use JavaScript for complex custom logic.
+
+---
+
+# LibreSprite JavaScript API Reference
+
+The following documentation covers the native LibreSprite JavaScript API for advanced scripting when the MCP tools are insufficient.
+
 # [class Sprite]
 ## Properties:
    - `palette`: read-only. Returns the sprite's palette.

--- a/src/libresprite_mcp/resources/reference.txt
+++ b/src/libresprite_mcp/resources/reference.txt
@@ -8,7 +8,7 @@ Creates a new sprite with specified dimensions and color mode.
 **Parameters:**
 - `width` (int): Width of the sprite in pixels
 - `height` (int): Height of the sprite in pixels  
-- `color_mode` (str): Color mode - "RGB", "RGBA", "GRAYSCALE", or "BITMAP"
+- `color_mode` (str): Color mode - "RGB", "INDEXED", "GRAYSCALE" or "BITMAP"
 
 **Returns:** Confirmation message
 

--- a/src/libresprite_mcp/resources/reference.txt
+++ b/src/libresprite_mcp/resources/reference.txt
@@ -30,19 +30,6 @@ Adds a new layer to the active sprite.
 create_layer(name="Character Layer")
 ```
 
-## Tool: set_active_layer
-Switch to a specific layer.
-
-**Parameters:**
-- `layer_number` (int): Layer index (0-based from bottom)
-
-**Returns:** Confirmation message
-
-**Example Usage:**
-```
-set_active_layer(layer_number=1)
-```
-
 ## Tool: fill_layer
 Fill the active layer with a solid color.
 
@@ -253,7 +240,7 @@ run_script(script=script)
 - Simple shape drawing (circles, rectangles, lines, ellipses)
 - Single pixel operations
 - Quick color fills and flood fills
-- Layer management (switching, deleting)
+- Layer deletion
 - Color replacement throughout images
 - Getting sprite information
 - Repetitive, straightforward operations
@@ -269,6 +256,7 @@ run_script(script=script)
 - When you need access to the full LibreSprite API
 - Complex gradient effects or procedural generation
 - Text rendering with custom fonts
+- Working with specific layers (use `sprite.layer(layerNumber)` to get layer objects)
 - Advanced layer manipulation and reordering
 - Complex selection operations
 

--- a/src/libresprite_mcp/script_templates.py
+++ b/src/libresprite_mcp/script_templates.py
@@ -1,0 +1,667 @@
+"""
+JavaScript script templates for common LibreSprite operations.
+"""
+
+# TODO: Fix create_sprite, create_layer
+
+class ScriptTemplates:
+    """
+    Generates JavaScript scripts for common LibreSprite operations.
+    """
+
+    def create_sprite(self, width: int, height: int, color_mode: str = "RGB") -> str:
+        """
+        Generate script to create a new sprite.
+
+        Args:
+            width: Width of the sprite
+            height: Height of the sprite
+            color_mode: Color mode (e.g., "RGB", "RGBA")
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    // Use the NewFile command to create a new sprite
+    app.command.setParameter("width", {width});
+    app.command.setParameter("height", {height});
+    app.command.setParameter("colorMode", ColorMode.{color_mode.upper()});
+    app.command.NewFile();
+    app.command.clearParameters();
+    
+    const sprite = app.activeSprite;
+    if (sprite) {{
+        console.log('Created new sprite: ' + sprite.width + 'x' + sprite.height + ' (' + sprite.colorMode + ')');
+        console.log('Active sprite now has ' + sprite.layerCount + ' layer(s)');
+    }} else {{
+        console.log('Failed to create sprite');
+    }}
+}} catch (e) {{
+    console.log('Error creating sprite: ' + e.message);
+}}
+"""
+    
+    def create_layer(self, name: str = "New Layer") -> str:
+        """
+        Generate script to create a new layer in the active sprite.
+
+        Args:
+            name: Name of the new layer
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        // Use the NewLayer command to create a new layer
+        app.command.setParameter("name", "{name}");
+        app.command.NewLayer();
+        app.command.clearParameters();
+        
+        console.log('Created new layer: {name}');
+        console.log('Sprite now has ' + sprite.layerCount + ' layer(s)');
+    }}
+}} catch (e) {{
+    console.log('Error creating layer: ' + e.message);
+}}
+"""
+    
+    def fill_layer(self, r: int, g: int, b: int, a: int = 255) -> str:
+        """
+        Generate script to fill the active layer with color.
+        
+        Args:
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const fillColor = col.rgba({r}, {g}, {b}, {a});
+            
+            // Clear the image with the specified color
+            img.clear(fillColor);
+            
+            console.log('Filled active layer with color rgba(' + {r} + ',' + {g} + ',' + {b} + ',' + {a} + ')');
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error filling layer: ' + e.message);
+}}
+"""
+    
+    def draw_circle(self, cx: int, cy: int, radius: int, r: int, g: int, b: int, a: int = 255, filled: bool = True) -> str:
+        """
+        Generate script to draw a circle.
+        
+        Args:
+            cx: Center x-coordinate
+            cy: Center y-coordinate
+            radius: Circle radius in pixels
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+            filled: Whether to fill the circle (default is True)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const circleColor = col.rgba({r}, {g}, {b}, {a});
+            
+            const cx = {cx};
+            const cy = {cy};
+            const radius = {radius};
+            const filled = {str(filled).lower()};
+            
+            for (let y = cy - radius; y <= cy + radius; y++) {{
+                for (let x = cx - radius; x <= cx + radius; x++) {{
+                    if (x >= 0 && x < img.width && y >= 0 && y < img.height) {{
+                        const dx = x - cx;
+                        const dy = y - cy;
+                        const distance = Math.sqrt(dx * dx + dy * dy);
+                        
+                        if (filled ? distance <= radius : Math.abs(distance - radius) < 1) {{
+                            img.putPixel(x, y, circleColor);
+                        }}
+                    }}
+                }}
+            }}
+            
+            console.log('Drew ' + (filled ? 'filled' : 'outlined') + ' circle at (' + cx + ',' + cy + ') radius ' + radius);
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error drawing circle: ' + e.message);
+}}
+"""
+    
+    def get_sprite_info(self) -> str:
+        """
+        Generate script to get sprite information.
+        
+        Returns:
+            JavaScript script as a string
+        """
+        return """
+try {
+    const sprite = app.activeSprite;
+    if (!sprite) {
+        console.log('No active sprite');
+    } else {
+        console.log('=== SPRITE INFO ===');
+        console.log('Dimensions: ' + sprite.width + 'x' + sprite.height);
+        console.log('Color Mode: ' + sprite.colorMode);
+        console.log('Layer Count: ' + sprite.layerCount);
+        console.log('Current Layer: ' + app.activeLayerNumber);
+        console.log('Current Frame: ' + app.activeFrameNumber);
+        
+        console.log('--- LAYER DETAILS ---');
+        for (let i = 0; i < sprite.layerCount; i++) {
+            const layer = sprite.layer(i);
+            if (layer) {
+                console.log('Layer ' + i + ': "' + layer.name + '" (visible: ' + layer.isVisible + ', editable: ' + layer.isEditable + ')');
+            }
+        }
+    }
+} catch (e) {
+    console.log('Error getting sprite info: ' + e.message);
+}
+"""
+
+    def draw_rectangle(self, x: int, y: int, width: int, height: int, r: int, g: int, b: int, a: int = 255, filled: bool = True) -> str:
+        """
+        Generate script to draw a rectangle.
+        
+        Args:
+            x: Top-left x coordinate
+            y: Top-left y coordinate
+            width: Rectangle width
+            height: Rectangle height
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+            filled: Whether to fill the rectangle (default is True)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const rectColor = col.rgba({r}, {g}, {b}, {a});
+            
+            const x = {x};
+            const y = {y};
+            const width = {width};
+            const height = {height};
+            const filled = {str(filled).lower()};
+            
+            if (filled) {{
+                // Fill the rectangle
+                for (let py = y; py < y + height; py++) {{
+                    for (let px = x; px < x + width; px++) {{
+                        if (px >= 0 && px < img.width && py >= 0 && py < img.height) {{
+                            img.putPixel(px, py, rectColor);
+                        }}
+                    }}
+                }}
+            }} else {{
+                // Draw rectangle outline
+                // Top and bottom edges
+                for (let px = x; px < x + width; px++) {{
+                    if (px >= 0 && px < img.width) {{
+                        if (y >= 0 && y < img.height) img.putPixel(px, y, rectColor);
+                        if (y + height - 1 >= 0 && y + height - 1 < img.height) img.putPixel(px, y + height - 1, rectColor);
+                    }}
+                }}
+                // Left and right edges
+                for (let py = y; py < y + height; py++) {{
+                    if (py >= 0 && py < img.height) {{
+                        if (x >= 0 && x < img.width) img.putPixel(x, py, rectColor);
+                        if (x + width - 1 >= 0 && x + width - 1 < img.width) img.putPixel(x + width - 1, py, rectColor);
+                    }}
+                }}
+            }}
+            
+            console.log('Drew ' + (filled ? 'filled' : 'outlined') + ' rectangle at (' + x + ',' + y + ') size ' + width + 'x' + height);
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error drawing rectangle: ' + e.message);
+}}
+"""
+
+    def draw_line(self, x1: int, y1: int, x2: int, y2: int, r: int, g: int, b: int, a: int = 255, thickness: int = 1) -> str:
+        """
+        Generate script to draw a line.
+        
+        Args:
+            x1: Start x coordinate
+            y1: Start y coordinate
+            x2: End x coordinate
+            y2: End y coordinate
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+            thickness: Line thickness in pixels (default is 1)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const lineColor = col.rgba({r}, {g}, {b}, {a});
+            
+            const x1 = {x1};
+            const y1 = {y1};
+            const x2 = {x2};
+            const y2 = {y2};
+            const thickness = {thickness};
+            
+            // Bresenham's line algorithm
+            const dx = Math.abs(x2 - x1);
+            const dy = Math.abs(y2 - y1);
+            const sx = x1 < x2 ? 1 : -1;
+            const sy = y1 < y2 ? 1 : -1;
+            let err = dx - dy;
+            
+            let x = x1;
+            let y = y1;
+            
+            while (true) {{
+                // Draw thick line by drawing a circle at each point
+                for (let ty = -Math.floor(thickness/2); ty <= Math.floor(thickness/2); ty++) {{
+                    for (let tx = -Math.floor(thickness/2); tx <= Math.floor(thickness/2); tx++) {{
+                        const px = x + tx;
+                        const py = y + ty;
+                        if (px >= 0 && px < img.width && py >= 0 && py < img.height) {{
+                            if (thickness === 1 || (tx * tx + ty * ty <= (thickness/2) * (thickness/2))) {{
+                                img.putPixel(px, py, lineColor);
+                            }}
+                        }}
+                    }}
+                }}
+                
+                if (x === x2 && y === y2) break;
+                
+                const e2 = 2 * err;
+                if (e2 > -dy) {{
+                    err -= dy;
+                    x += sx;
+                }}
+                if (e2 < dx) {{
+                    err += dx;
+                    y += sy;
+                }}
+            }}
+            
+            console.log('Drew line from (' + x1 + ',' + y1 + ') to (' + x2 + ',' + y2 + ') thickness ' + thickness);
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error drawing line: ' + e.message);
+}}
+"""
+
+    def draw_ellipse(self, cx: int, cy: int, width: int, height: int, r: int, g: int, b: int, a: int = 255, filled: bool = True) -> str:
+        """
+        Generate script to draw an ellipse.
+        
+        Args:
+            cx: Center x coordinate
+            cy: Center y coordinate
+            width: Ellipse width
+            height: Ellipse height
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+            filled: Whether to fill the ellipse (default is True)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const ellipseColor = col.rgba({r}, {g}, {b}, {a});
+            
+            const cx = {cx};
+            const cy = {cy};
+            const width = {width};
+            const height = {height};
+            const filled = {str(filled).lower()};
+            
+            const a = width / 2;
+            const b = height / 2;
+            
+            for (let y = cy - Math.ceil(b); y <= cy + Math.ceil(b); y++) {{
+                for (let x = cx - Math.ceil(a); x <= cx + Math.ceil(a); x++) {{
+                    if (x >= 0 && x < img.width && y >= 0 && y < img.height) {{
+                        const dx = x - cx;
+                        const dy = y - cy;
+                        const ellipseEq = (dx * dx) / (a * a) + (dy * dy) / (b * b);
+                        
+                        if (filled) {{
+                            if (ellipseEq <= 1) {{
+                                img.putPixel(x, y, ellipseColor);
+                            }}
+                        }} else {{
+                            // Draw outline - check if point is close to ellipse edge
+                            if (Math.abs(ellipseEq - 1) < 0.1) {{
+                                img.putPixel(x, y, ellipseColor);
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+            
+            console.log('Drew ' + (filled ? 'filled' : 'outlined') + ' ellipse at (' + cx + ',' + cy + ') size ' + width + 'x' + height);
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error drawing ellipse: ' + e.message);
+}}
+"""
+
+    def put_pixel(self, x: int, y: int, r: int, g: int, b: int, a: int = 255) -> str:
+        """
+        Generate script to set a pixel color.
+        
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const x = {x};
+            const y = {y};
+            
+            if (x >= 0 && x < img.width && y >= 0 && y < img.height) {{
+                const col = app.pixelColor;
+                const pixelColor = col.rgba({r}, {g}, {b}, {a});
+                img.putPixel(x, y, pixelColor);
+                console.log('Set pixel at (' + x + ',' + y + ') to rgba(' + {r} + ',' + {g} + ',' + {b} + ',' + {a} + ')');
+            }} else {{
+                console.log('Pixel coordinates (' + x + ',' + y + ') are out of bounds');
+            }}
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error setting pixel: ' + e.message);
+}}
+"""
+
+    def flood_fill(self, x: int, y: int, r: int, g: int, b: int, a: int = 255) -> str:
+        """
+        Generate script to flood fill an area with color.
+        
+        Args:
+            x: X coordinate to start fill
+            y: Y coordinate to start fill
+            r: Red component (0-255)
+            g: Green component (0-255)
+            b: Blue component (0-255)
+            a: Alpha component (0-255, default is 255)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const startX = {x};
+            const startY = {y};
+            
+            if (startX >= 0 && startX < img.width && startY >= 0 && startY < img.height) {{
+                const col = app.pixelColor;
+                const fillColor = col.rgba({r}, {g}, {b}, {a});
+                const targetColor = img.getPixel(startX, startY);
+                
+                if (targetColor === fillColor) {{
+                    console.log('Target color is the same as fill color, no action needed');
+                    return;
+                }}
+                
+                const stack = [[startX, startY]];
+                let fillCount = 0;
+                
+                while (stack.length > 0) {{
+                    const [x, y] = stack.pop();
+                    
+                    if (x < 0 || x >= img.width || y < 0 || y >= img.height) continue;
+                    if (img.getPixel(x, y) !== targetColor) continue;
+                    
+                    img.putPixel(x, y, fillColor);
+                    fillCount++;
+                    
+                    stack.push([x + 1, y]);
+                    stack.push([x - 1, y]);
+                    stack.push([x, y + 1]);
+                    stack.push([x, y - 1]);
+                }}
+                
+                console.log('Flood fill completed at (' + startX + ',' + startY + '), filled ' + fillCount + ' pixels');
+            }} else {{
+                console.log('Start coordinates (' + startX + ',' + startY + ') are out of bounds');
+            }}
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error flood filling: ' + e.message);
+}}
+"""
+
+    def set_active_layer(self, layer_number: int) -> str:
+        """
+        Generate script to switch to a specific layer.
+        
+        Args:
+            layer_number: Layer index (0-based from bottom)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const layerNumber = {layer_number};
+        
+        if (layerNumber >= 0 && layerNumber < sprite.layerCount) {{
+            // Use the GotoLayer command - this might not exist, so we'll use a workaround
+            // Since there's no direct layer switching in the API, we'll document the current layer
+            const layer = sprite.layer(layerNumber);
+            if (layer) {{
+                console.log('Switching to layer ' + layerNumber + ': "' + layer.name + '"');
+                console.log('Note: Layer switching via script may be limited. Use UI to switch layers.');
+                console.log('Current active layer: ' + app.activeLayerNumber);
+            }} else {{
+                console.log('Layer ' + layerNumber + ' not found');
+            }}
+        }} else {{
+            console.log('Layer number ' + layerNumber + ' is out of range (0-' + (sprite.layerCount - 1) + ')');
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error switching layer: ' + e.message);
+}}
+"""
+
+    def delete_layer(self, layer_number: int) -> str:
+        """
+        Generate script to delete a layer.
+        
+        Args:
+            layer_number: Layer index (0-based from bottom)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const layerNumber = {layer_number};
+        
+        if (layerNumber >= 0 && layerNumber < sprite.layerCount) {{
+            if (sprite.layerCount <= 1) {{
+                console.log('Cannot delete the only remaining layer');
+                return;
+            }}
+            
+            const layer = sprite.layer(layerNumber);
+            if (layer) {{
+                const layerName = layer.name;
+                // Use RemoveLayer command
+                app.command.RemoveLayer();
+                console.log('Deleted layer ' + layerNumber + ': "' + layerName + '"');
+                console.log('Sprite now has ' + sprite.layerCount + ' layer(s)');
+            }} else {{
+                console.log('Layer ' + layerNumber + ' not found');
+            }}
+        }} else {{
+            console.log('Layer number ' + layerNumber + ' is out of range (0-' + (sprite.layerCount - 1) + ')');
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error deleting layer: ' + e.message);
+}}
+"""
+
+
+    def replace_color(self, old_r: int, old_g: int, old_b: int, new_r: int, new_g: int, new_b: int, new_a: int = 255) -> str:
+        """
+        Generate script to replace one color with another throughout the image.
+        
+        Args:
+            old_r: Old color red component (0-255)
+            old_g: Old color green component (0-255)
+            old_b: Old color blue component (0-255)
+            new_r: New color red component (0-255)
+            new_g: New color green component (0-255)
+            new_b: New color blue component (0-255)
+            new_a: New color alpha component (0-255, default is 255)
+
+        Returns:
+            JavaScript script as a string
+        """
+        return f"""
+try {{
+    const sprite = app.activeSprite;
+    if (!sprite) {{
+        console.log('No active sprite');
+    }} else {{
+        const img = app.activeImage;
+        if (!img) {{
+            console.log('No active image');
+        }} else {{
+            const col = app.pixelColor;
+            const oldColor = col.rgba({old_r}, {old_g}, {old_b}, 255); // Assume full alpha for comparison
+            const newColor = col.rgba({new_r}, {new_g}, {new_b}, {new_a});
+            
+            let replacedCount = 0;
+            
+            for (let y = 0; y < img.height; y++) {{
+                for (let x = 0; x < img.width; x++) {{
+                    const pixelColor = img.getPixel(x, y);
+                    // Compare RGB components (ignore alpha for old color)
+                    if (col.rgbaR(pixelColor) === {old_r} && 
+                        col.rgbaG(pixelColor) === {old_g} && 
+                        col.rgbaB(pixelColor) === {old_b}) {{
+                        img.putPixel(x, y, newColor);
+                        replacedCount++;
+                    }}
+                }}
+            }}
+            
+            console.log('Replaced ' + replacedCount + ' pixels from rgba(' + {old_r} + ',' + {old_g} + ',' + {old_b} + ',*) to rgba(' + {new_r} + ',' + {new_g} + ',' + {new_b} + ',' + {new_a} + ')');
+        }}
+    }}
+}} catch (e) {{
+    console.log('Error replacing color: ' + e.message);
+}}
+"""

--- a/src/libresprite_mcp/script_templates.py
+++ b/src/libresprite_mcp/script_templates.py
@@ -531,44 +531,6 @@ try {{
 }}
 """
 
-    def set_active_layer(self, layer_number: int) -> str:
-        """
-        Generate script to switch to a specific layer.
-        
-        Args:
-            layer_number: Layer index (0-based from bottom)
-
-        Returns:
-            JavaScript script as a string
-        """
-        return f"""
-try {{
-    const sprite = app.activeSprite;
-    if (!sprite) {{
-        console.log('No active sprite');
-    }} else {{
-        const layerNumber = {layer_number};
-        
-        if (layerNumber >= 0 && layerNumber < sprite.layerCount) {{
-            // Use the GotoLayer command - this might not exist, so we'll use a workaround
-            // Since there's no direct layer switching in the API, we'll document the current layer
-            const layer = sprite.layer(layerNumber);
-            if (layer) {{
-                console.log('Switching to layer ' + layerNumber + ': "' + layer.name + '"');
-                console.log('Note: Layer switching via script may be limited. Use UI to switch layers.');
-                console.log('Current active layer: ' + app.activeLayerNumber);
-            }} else {{
-                console.log('Layer ' + layerNumber + ' not found');
-            }}
-        }} else {{
-            console.log('Layer number ' + layerNumber + ' is out of range (0-' + (sprite.layerCount - 1) + ')');
-        }}
-    }}
-}} catch (e) {{
-    console.log('Error switching layer: ' + e.message);
-}}
-"""
-
     def delete_layer(self, layer_number: int) -> str:
         """
         Generate script to delete a layer.

--- a/src/libresprite_mcp/script_templates.py
+++ b/src/libresprite_mcp/script_templates.py
@@ -2,8 +2,6 @@
 JavaScript script templates for common LibreSprite operations.
 """
 
-# FIXME: set_active_layer doesn't work
-
 class ScriptTemplates:
     """
     Generates JavaScript scripts for common LibreSprite operations.

--- a/src/libresprite_mcp/script_templates.py
+++ b/src/libresprite_mcp/script_templates.py
@@ -2,7 +2,7 @@
 JavaScript script templates for common LibreSprite operations.
 """
 
-# TODO: Fix create_sprite, create_layer
+# FIXME: set_active_layer doesn't work
 
 class ScriptTemplates:
     """

--- a/src/libresprite_mcp/script_templates.py
+++ b/src/libresprite_mcp/script_templates.py
@@ -16,7 +16,7 @@ class ScriptTemplates:
         Args:
             width: Width of the sprite
             height: Height of the sprite
-            color_mode: Color mode (e.g., "RGB", "RGBA")
+            color_mode: Color mode ("RGB", "INDEXED", "GRAYSCALE", "BITMAP")
 
         Returns:
             JavaScript script as a string


### PR DESCRIPTION
# What's this PR doing?

- Adds new tools for various common operations in Libresprite:
  - `create_sprite`
  - `create_layer`
  - `fill_layer`
  - `draw_circle`
  - `draw_rectangle`
  - `draw_line`
  - `draw_ellipse`
  - `put_pixel`
  - `flood_fill`
  - `get_sprite_info`
  - `delete_layer`
  - `replace_color`
- Expands documentation and examples to demonstrate usage of these new tools and combined workflows. The prompt now advises using `run_script` only for advanced custom cases.